### PR TITLE
handle fb fail

### DIFF
--- a/src/app/shared/testing/services.spy.ts
+++ b/src/app/shared/testing/services.spy.ts
@@ -50,6 +50,9 @@ export class MyWorkOrdersServiceSpy {
 
 export class ActivatedRouteSpy {
   get = jasmine.createSpy("snapshot").and.callThrough();
+  queryParams = observableOf({
+    "fb-fail": "true",
+  });
 }
 
 export const ActivatedRouteStub = {

--- a/src/app/welcome/welcome.component.spec.ts
+++ b/src/app/welcome/welcome.component.spec.ts
@@ -1,18 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { WelcomeComponent } from "./welcome.component";
 import { ConfigsService } from "../configs/configs.service";
 import { AuthService } from "../shared/index";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import {
+  ActivatedRouteSpy,
   AuthServiceSpy,
   ConfigsServiceSpy,
   getConfigsList,
   RouterSpy,
 } from "../shared/testing";
+import { MessageService } from "primeng/api";
 
 describe("WelcomeComponent", () => {
   let component: WelcomeComponent;
   let fixture: ComponentFixture<WelcomeComponent>;
+  const messageService = jasmine.createSpyObj("MessageService", ["add"]);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,6 +30,8 @@ describe("WelcomeComponent", () => {
             { provide: ConfigsService, useClass: ConfigsServiceSpy },
             { provide: AuthService, useClass: AuthServiceSpy },
             { provide: Router, useClass: RouterSpy },
+            { provide: ActivatedRoute, useClass: ActivatedRouteSpy },
+            { provide: MessageService, useValue: messageService },
           ],
         },
       })
@@ -44,5 +52,11 @@ describe("WelcomeComponent", () => {
     getConfigsList().map((conf) => {
       expect(component.serverData).toContain(conf);
     });
+  });
+
+  it("should call message service when fb-login fails", () => {
+    // We know the activated route params contains the query that triggers the call
+    const add = messageService.add.and.callFake(() => "");
+    expect(add.calls.any()).toBe(true, "messsages add called");
   });
 });

--- a/src/app/welcome/welcome.component.ts
+++ b/src/app/welcome/welcome.component.ts
@@ -1,9 +1,12 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ConfigsService } from "../configs/configs.service";
 import { AuthService } from "../shared/index";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { environment } from "../../environments/environment";
 import { Config } from "../shared/models/config";
+import { map, pluck, takeWhile, tap } from "rxjs/operators";
+import { Observable } from "rxjs";
+import { MessageService } from "primeng/api";
 
 enum DashboardState {
   None = "None",
@@ -16,7 +19,7 @@ enum DashboardState {
   templateUrl: "./welcome.component.html",
   styleUrls: ["./welcome.component.css"],
 })
-export class WelcomeComponent implements OnInit {
+export class WelcomeComponent implements OnInit, OnDestroy {
   private alive = true;
 
   facebookAppId: string;
@@ -29,6 +32,7 @@ export class WelcomeComponent implements OnInit {
   macheteOutage: boolean;
   outageMessage: string;
   serverData: Config[];
+  query$: Observable<boolean>;
 
   public roleState: DashboardState = DashboardState.None;
   public hirerLinks = [
@@ -74,10 +78,43 @@ export class WelcomeComponent implements OnInit {
   constructor(
     private cfgService: ConfigsService,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private messageServ: MessageService
   ) {}
 
+  /**
+   * Catches a query param passed by the api redirect result when login fails
+   * Currently we are only expecting one type of failure from the FB login flow:
+   * https://github.com/SavageLearning/Machete/issues/673
+   */
+  private handleQueryParams(): void {
+    this.activatedRoute.queryParams
+      .pipe(
+        takeWhile(() => this.alive),
+        pluck("fb-fail"),
+        map((fbFail: string) => /true/i.test(fbFail)),
+        tap((fbFail: boolean) => {
+          if (fbFail) {
+            this.messageServ.add({
+              life: 18000,
+              key: "root-toast-notifications",
+              severity: "error",
+              summary: `Facebook login failed`,
+              detail: `Machete was unable to confirm your email address via Facebook login.
+              Please click on Login below to see alternate login methods.
+              You may also check Facebook's instructions to confirm your email and try
+              again when your email is confirmed`,
+            });
+          }
+        })
+      )
+      .subscribe();
+  }
+
   ngOnInit(): void {
+    //
+    this.handleQueryParams();
     this.cfgService.getAllConfigs().subscribe(
       (data) => {
         this.serverData = data;
@@ -131,6 +168,10 @@ export class WelcomeComponent implements OnInit {
       "&" +
       "state=" +
       this.macheteSessionId;
+  }
+
+  ngOnDestroy(): void {
+    this.alive = false;
   }
 
   // DEPRECATED


### PR DESCRIPTION
### Changes:
- catches a login failure with a `fb-fail=true` query param in the welcome component.
- when param is passed and can parse from string to boolean (true), a toast is displayed with the error and alternate steps