### PR TITLE
fix scroller and style

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -60,6 +60,8 @@
               "node_modules/primeicons/primeicons.css",
               "node_modules/codemirror/lib/codemirror.css",
               "node_modules/codemirror/theme/monokai.css",
+              "node_modules/codemirror/addon/scroll/simplescrollbars.css",
+              "node_modules/codemirror/addon/hint/show-hint.css",
               "src/styles.scss"
             ],
             "scripts": [

--- a/src/app/reports/editor/editor.component.html
+++ b/src/app/reports/editor/editor.component.html
@@ -38,7 +38,7 @@
 
 </div>
 <ng-container *ngIf="editing">
-  <div style="height: auto">
+  <div>
     <ngx-codemirror
       [options]="editorOptions"
       [(ngModel)]="sql"

--- a/src/app/reports/editor/editor.component.scss
+++ b/src/app/reports/editor/editor.component.scss
@@ -1,4 +1,3 @@
-:host ::ng-deep .cm-s-monokai.CodeMirror {
-  height: auto;
-  max-height: 800px;
+:host ::ng-deep .CodeMirror {
+  height: 80vh;
 }

--- a/src/app/reports/editor/editor.component.ts
+++ b/src/app/reports/editor/editor.component.ts
@@ -8,9 +8,12 @@ import {
 import { SqlEditorState } from "../report-detail/report-detail.component";
 import "codemirror/mode/sql/sql";
 import "codemirror/addon/edit/matchbrackets";
-import "codemirror/addon/dialog/dialog";
+import "codemirror/addon/edit/closebrackets";
 import "codemirror/addon/edit/closetag";
 import "codemirror/addon/selection/active-line";
+import "codemirror/addon/hint/show-hint";
+import "codemirror/addon/hint/sql-hint";
+import "codemirror/addon/scroll/simplescrollbars";
 
 export interface IEditorDetails {
   sql?: string;
@@ -32,7 +35,10 @@ export class EditorComponent {
     smartIndent: true,
     matchBrackets: true,
     autoCloseTags: true,
+    autoCloseBrackets: true,
     styleActiveLine: true,
+    extraKeys: { "Ctrl-Space": "autocomplete" },
+    scrollbarStyle: "overlay",
   };
   editing = false;
 


### PR DESCRIPTION
Changes:
- fixes broken code editor styles
- adds a prettier scroller to code editor
- adds auto complete command: `Ctrl-Space`

Expect:
- sql editor auto-adjusts to 80% view port height
- pretty scroller is visible
- type `SEL`, then key: Ctr + Space, it should auto-complete to `SELECT`
![image](https://user-images.githubusercontent.com/26440947/148442861-991313c6-1c43-4c7d-83b8-3c5259c29d52.png)
